### PR TITLE
Add membership plan API and dynamic loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ This contains everything you need to run your app locally.
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+3. (Optional) start the example API server:
+   `npm run server`
+4. Run the app:
    `npm run dev`

--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,4 @@
-import { UserMembershipType, WorkerMembershipType } from "./types";
+import { UserMembershipType, WorkerMembershipType, UserMembershipPlan } from "./types";
 
 export const APP_NAME = "Fundy"; // Updated App Name
 export const DEFAULT_AVATAR_URL = "https://picsum.photos/200";
@@ -14,7 +14,7 @@ export const BANK_DETAILS = {
 
 export const CREDIT_PRICE_VND = 240; // 1 credit = 240 VND
 
-export const USER_MEMBERSHIP_PLANS = {
+export let USER_MEMBERSHIP_PLANS: Record<UserMembershipType, UserMembershipPlan> = {
   [UserMembershipType.Free]: { 
     name: "Miễn Phí",
     price: 0,
@@ -46,6 +46,20 @@ export const USER_MEMBERSHIP_PLANS = {
     ],
   },
 };
+
+export async function loadUserMembershipPlans() {
+  try {
+    const res = await fetch('http://localhost:3001/api/memberships');
+    if (!res.ok) throw new Error('Failed to fetch membership plans');
+    const plans: UserMembershipPlan[] = await res.json();
+    USER_MEMBERSHIP_PLANS = plans.reduce((acc, plan) => {
+      acc[plan.key as UserMembershipType] = plan;
+      return acc;
+    }, {} as Record<UserMembershipType, UserMembershipPlan>);
+  } catch (err) {
+    console.error('Unable to load membership plans', err);
+  }
+}
 
 export const WORKER_MEMBERSHIP_PLANS = {
   [WorkerMembershipType.WorkerAdvanced]: {

--- a/index.tsx
+++ b/index.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { AuthProvider } from './contexts/AuthContext';
 import { HashRouter } from 'react-router-dom';
+import { loadUserMembershipPlans } from './constants';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,13 +12,15 @@ if (!rootElement) {
 }
 
 const root = ReactDOM.createRoot(rootElement);
-root.render(
-  <React.StrictMode>
-    <HashRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    </HashRouter>
-  </React.StrictMode>
-);
+loadUserMembershipPlans().finally(() => {
+  root.render(
+    <React.StrictMode>
+      <HashRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </HashRouter>
+    </React.StrictMode>
+  );
+});
     

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/server.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,87 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// In-memory "database"
+let memberships = [
+  {
+    id: 'Free',
+    key: 'Free',
+    name: 'Miễn Phí',
+    price: 0,
+    features: [
+      '5 phút AI trò chuyện điện thoại',
+      '20 lượt chat tự động qua app/website',
+      'Truy cập các tính năng cơ bản'
+    ]
+  },
+  {
+    id: 'Advanced',
+    key: 'Advanced',
+    name: 'Nâng Cao (User)',
+    price: 1500000,
+    features: [
+      '100 phút AI trò chuyện điện thoại',
+      '500 lượt chat tự động qua app/website (≈ 80-100 tin nhắn/ngày)',
+      'Hỗ trợ xây dựng Mô Hình Kinh Doanh',
+      'Hỗ trợ chuẩn bị Gọi Vốn'
+    ]
+  },
+  {
+    id: 'Professional',
+    key: 'Professional',
+    name: 'Chuyên Nghiệp (User)',
+    price: 15000000,
+    features: [
+      '1,200 phút AI trò chuyện điện thoại (≈ 20-25 cuộc gọi/ngày, full tháng)',
+      '6,000 lượt chat tự động (≈ 200 tin nhắn/ngày)',
+      'Tất cả tính năng của gói Nâng Cao',
+      'Tư vấn Pháp Lý cơ bản qua AI',
+      'Hỗ trợ Tìm Nhân Tài'
+    ]
+  }
+];
+
+let users = [
+  { id: '1', name: 'Demo User', membership: 'Free' }
+];
+
+app.get('/api/memberships', (req, res) => {
+  res.json(memberships);
+});
+
+app.post('/api/memberships', (req, res) => {
+  const newPlan = { id: Date.now().toString(), ...req.body };
+  memberships.push(newPlan);
+  res.status(201).json(newPlan);
+});
+
+app.put('/api/memberships/:id', (req, res) => {
+  const idx = memberships.findIndex(m => m.id === req.params.id);
+  if (idx === -1) return res.status(404).end();
+  memberships[idx] = { ...memberships[idx], ...req.body };
+  res.json(memberships[idx]);
+});
+
+app.delete('/api/memberships/:id', (req, res) => {
+  const idx = memberships.findIndex(m => m.id === req.params.id);
+  if (idx === -1) return res.status(404).end();
+  memberships.splice(idx, 1);
+  res.status(204).end();
+});
+
+app.put('/api/users/:id/membership', (req, res) => {
+  const user = users.find(u => u.id === req.params.id);
+  if (!user) return res.status(404).end();
+  const { membership } = req.body;
+  user.membership = membership;
+  res.json(user);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/types.ts
+++ b/types.ts
@@ -179,3 +179,10 @@ export interface WorkerMembershipPlan {
   price: number;
   features: string[];
 }
+
+export interface UserMembershipPlan {
+  key: UserMembershipType;
+  name: string;
+  price: number;
+  features: string[];
+}


### PR DESCRIPTION
## Summary
- add an Express server providing `/api/memberships` CRUD endpoints and the ability to update a user's membership
- expose a `loadUserMembershipPlans` helper and fetch plans from the API
- load membership plans before rendering React app
- update README with server instructions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684f3b2d8a4c8325bc53fe1d6325e7ac