### PR TITLE
Integrate payment API calls

### DIFF
--- a/components/dashboard/DashboardOverviewSection.tsx
+++ b/components/dashboard/DashboardOverviewSection.tsx
@@ -22,25 +22,12 @@ const DashboardOverviewSection: React.FC<DashboardOverviewSectionProps> = ({ set
     return <LoadingSpinner message="Loading user data..." />;
   }
 
-  const handleAddCreditsSuccess = (amount: number) => {
-    if (user) {
-      updateUser({ credits: (user.credits || 0) + amount });
-    }
+  const handleAddCreditsSuccess = (_amount: number) => {
+    // User state is updated in AuthContext
   };
 
-  const handleUpgradeMembershipSuccess = (newMembershipPlanKey: any) => { // Assuming this key is UserMembershipType
-     if (user) {
-        // Find plan name from USER_MEMBERSHIP_PLANS based on key
-        // This part depends on what onPaymentSuccess actually returns.
-        // For now, let's assume it returns the key, and we update the membership enum and plan name.
-        const planDetails = (USER_MEMBERSHIP_PLANS as any)[newMembershipPlanKey];
-        if (planDetails) {
-            updateUser({ 
-                membership: newMembershipPlanKey, // The enum key
-                membershipPlanName: planDetails.name 
-            });
-        }
-    }
+  const handleUpgradeMembershipSuccess = (_newMembershipPlanKey: any) => {
+    // User state updated in AuthContext
   };
 
   const handleAskAssistant = () => {

--- a/components/dashboard/ProfileDropdown.tsx
+++ b/components/dashboard/ProfileDropdown.tsx
@@ -34,18 +34,12 @@ const ProfileDropdown: React.FC = () => {
     navigate('/login');
   };
   
-  const handleAddCreditsSuccess = (amount: number) => {
-    updateUser({ credits: (user.credits || 0) + amount });
+  const handleAddCreditsSuccess = (_amount: number) => {
+    // State updated in AuthContext
   };
 
-  const handleUpgradeUserMembershipSuccess = (newMembershipPlanKey: UserMembershipType) => {
-    const planDetails = USER_MEMBERSHIP_PLANS[newMembershipPlanKey];
-    if (planDetails) {
-        updateUser({ 
-            membership: newMembershipPlanKey, // The enum key
-            membershipPlanName: planDetails.name 
-        });
-    }
+  const handleUpgradeUserMembershipSuccess = (_newMembershipPlanKey: UserMembershipType) => {
+    // State updated in AuthContext
   };
 
   const handleUpgradeWorkerMembershipSuccess = (newMembershipPlanKey: WorkerMembershipType) => {

--- a/services/paymentService.ts
+++ b/services/paymentService.ts
@@ -1,0 +1,46 @@
+export interface PaymentResponse {
+  success: boolean;
+  message: string;
+  credits?: number;
+  membership?: string;
+}
+
+export const purchaseCredits = async (userId: string, credits: number): Promise<PaymentResponse> => {
+  try {
+    const response = await fetch('/api/credits/purchase', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ userId, credits })
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      return { success: false, message: data?.message || 'Payment failed' };
+    }
+    const data = await response.json();
+    return { success: true, message: data.message || 'Payment successful', credits: data.credits };
+  } catch (error: any) {
+    return { success: false, message: error.message || 'Network error' };
+  }
+};
+
+export const upgradeMembership = async (userId: string, membership: string): Promise<PaymentResponse> => {
+  try {
+    const response = await fetch('/api/membership/upgrade', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ userId, membership })
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      return { success: false, message: data?.message || 'Upgrade failed' };
+    }
+    const data = await response.json();
+    return { success: true, message: data.message || 'Upgrade successful', membership: data.membership };
+  } catch (error: any) {
+    return { success: false, message: error.message || 'Network error' };
+  }
+};


### PR DESCRIPTION
## Summary
- add `paymentService` with `purchaseCredits` and `upgradeMembership` API calls
- update `CreditModal` and `MembershipModal` to use API endpoints and show status messages
- expose payment helpers via `AuthContext` so user state updates after a purchase
- adjust dashboard components to rely on context updates

## Testing
- `npx tsc --noEmit` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_b_684f3b31a0b483258a30bfa07d1d4cc7