### PR TITLE
Update README with server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,12 @@ This contains everything you need to run your app locally.
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+3. Configure the backend by specifying a port.  Add `PORT=3000` (or your
+   preferred value) to `.env.local` or export it in your shell.
+4. Start the Express server:
+   `npm run server`
+5. In another terminal, start the frontend:
    `npm run dev`
+   
+   You can also use a single script that launches both processes if provided
+   (for example `npm run start`).


### PR DESCRIPTION
## Summary
- document how to start the Express backend using `npm run server`
- mention required `PORT` variable
- show how to run frontend and backend at the same time

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684f3c9c3718832591e7854be4799cd6