### PR TITLE
Switch services to fetch Express API

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
 import { User, UserMembershipType } from '../types'; // UserMembershipType is the enum for user.membership
-import { mockLogin, mockLogout, mockRegister } from '../services/authService';
+import { login as apiLogin, logout as apiLogout, register as apiRegister } from '../services/authService';
 import { USER_MEMBERSHIP_PLANS } from '../constants'; // For default plan name
 
 interface AuthContextType {
@@ -42,7 +42,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const login = useCallback(async (email: string, pass: string) => {
     setLoading(true);
     try {
-      const result = await mockLogin(email, pass);
+      const result = await apiLogin(email, pass);
       if (result) {
         localStorage.setItem('authUser', JSON.stringify(result));
         setUser(result);
@@ -58,7 +58,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const logout = useCallback(async () => {
     setLoading(true);
-    await mockLogout();
+    await apiLogout();
     localStorage.removeItem('authUser');
     setUser(null);
     setLoading(false);
@@ -66,7 +66,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const register = useCallback(async (name: string, email: string, pass: string) => {
     setLoading(true);
-    const result = await mockRegister(name, email, pass);
+    const result = await apiRegister(name, email, pass);
     if (result) {
       localStorage.setItem('authUser', JSON.stringify(result));
       setUser(result);

--- a/services/adminDataService.ts
+++ b/services/adminDataService.ts
@@ -1,116 +1,66 @@
+import { User, AdminOverviewStats, GeneratedCode } from '../types';
 
-import { User, UserMembershipType, AdminOverviewStats, GeneratedCode } from '../types';
-import { DEFAULT_AVATAR_URL, USER_MEMBERSHIP_PLANS, CREDIT_PRICE_VND } from '../constants';
-
-let mockUsers: User[] = [
-  { id: 'usr_001', name: 'Alice Johnson', email: 'alice@example.com', phone: '555-0101', membership: UserMembershipType.Advanced, credits: 150, avatarUrl: DEFAULT_AVATAR_URL, membershipRoleType: 'user' },
-  { id: 'usr_002', name: 'Bob Smith', email: 'bob@example.com', phone: '555-0102', membership: UserMembershipType.Free, credits: 5, avatarUrl: DEFAULT_AVATAR_URL, membershipRoleType: 'user' },
-  { id: 'usr_003', name: 'Carol White', email: 'carol@example.com', phone: '555-0103', membership: UserMembershipType.Professional, credits: 1200, avatarUrl: DEFAULT_AVATAR_URL, membershipRoleType: 'user' },
-  { id: 'usr_004', name: 'David Brown', email: 'david@example.com', phone: '555-0104', membership: UserMembershipType.Free, credits: 20, avatarUrl: DEFAULT_AVATAR_URL, membershipRoleType: 'user' },
-  { id: 'usr_005', name: 'Eve Davis', email: 'eve@example.com', phone: '555-0105', membership: UserMembershipType.Advanced, credits: 80, avatarUrl: DEFAULT_AVATAR_URL, membershipRoleType: 'user' },
-];
-
-mockUsers = mockUsers.map(u => ({
-    ...u,
-    membershipPlanName: USER_MEMBERSHIP_PLANS[u.membership].name
-}));
-
-
-let mockGeneratedCodes: GeneratedCode[] = [
-    { id: 'code_001', code: 'PROMO2024', type: 'coupon', details: '15% off first month', isUsed: false, createdAt: new Date(Date.now() - 86400000 * 5) },
-    { id: 'code_002', code: 'ADVFREE01', type: 'membership', details: 'Advanced Plan - 1 Month Free', isUsed: true, createdAt: new Date(Date.now() - 86400000 * 10) },
-    { id: 'code_003', code: 'SAVEBIG10', type: 'coupon', details: '10 USD off', isUsed: false, createdAt: new Date(Date.now() - 86400000 * 2) },
-];
-
+const fetchJson = async <T>(url: string, options?: RequestInit): Promise<T> => {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+};
 
 export const getAdminOverviewStats = async (): Promise<AdminOverviewStats> => {
-  return new Promise(resolve => {
-    setTimeout(() => resolve({
-      totalActiveUsers: mockUsers.length,
-      totalCreditsUsed: mockUsers.reduce((sum, user) => sum + (user.credits < 500 ? (500-user.credits) : 0),0) + 5000, // Mock usage
-      totalRevenueFromCredits: (mockUsers.reduce((sum, user) => sum + (user.credits < 500 ? (500-user.credits) : 0),0) + 5000) * CREDIT_PRICE_VND * 0.7, // Mock
-      totalRevenueFromMemberships: mockUsers.filter(u=>u.membership !== UserMembershipType.Free).length * 1000000, // Mock
-      recentChatSnippets: [
-        { user: 'alice@example.com', snippet: 'Can you help me with my pitch deck?', timestamp: new Date(Date.now() - 3600000) },
-        { user: 'bob@example.com', snippet: 'What are the first steps to fundraising?', timestamp: new Date(Date.now() - 7200000) },
-      ],
-      aiSuggestions: [
-        "Consider adding a tutorial for new users on the checklist feature.",
-        "Monitor chat topics to identify common user pain points.",
-        "Offer a discount for annual membership subscriptions."
-      ]
-    }), 500);
-  });
+  return fetchJson('/api/admin/overview');
 };
 
 export const getManagedUsers = async (): Promise<User[]> => {
-  return new Promise(resolve => {
-    setTimeout(() => resolve([...mockUsers]), 500);
-  });
+  return fetchJson('/api/admin/users');
 };
 
 export const updateManagedUser = async (userToUpdate: User): Promise<User | null> => {
-    return new Promise(resolve => {
-        setTimeout(() => {
-            const index = mockUsers.findIndex(u => u.id === userToUpdate.id);
-            if (index !== -1) {
-                mockUsers[index] = { ...mockUsers[index], ...userToUpdate };
-                // Update membershipPlanName if membership enum changed
-                if (userToUpdate.membership && USER_MEMBERSHIP_PLANS[userToUpdate.membership]) {
-                  mockUsers[index].membershipPlanName = USER_MEMBERSHIP_PLANS[userToUpdate.membership].name;
-                }
-                resolve(mockUsers[index]);
-            } else {
-                resolve(null);
-            }
-        }, 300);
-    });
+  return fetchJson(`/api/admin/users/${userToUpdate.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(userToUpdate)
+  });
 };
 
 export const deleteManagedUser = async (userId: string): Promise<boolean> => {
-    return new Promise(resolve => {
-        setTimeout(() => {
-            const initialLength = mockUsers.length;
-            mockUsers = mockUsers.filter(u => u.id !== userId);
-            resolve(mockUsers.length < initialLength);
-        }, 300);
-    });
+  const res = await fetch(`/api/admin/users/${userId}`, { method: 'DELETE' });
+  return res.ok;
 };
 
-export const getMembershipPlansEditable = async (): Promise<typeof USER_MEMBERSHIP_PLANS> => {
-    return new Promise(resolve => {
-        setTimeout(() => resolve(JSON.parse(JSON.stringify(USER_MEMBERSHIP_PLANS))), 200); // Deep copy
-    });
+export const getMembershipPlansEditable = async (): Promise<any> => {
+  return fetchJson('/api/admin/membership-plans');
 };
 
-export const updateMembershipPlanMock = async (planKey: keyof typeof USER_MEMBERSHIP_PLANS, updatedPlan: any) => {
-    console.log("Mock update membership plan:", planKey, updatedPlan);
-    // In a real app, this would update constants or a backend.
-    // For this mock, we'll just log it. We can't easily update the imported USER_MEMBERSHIP_PLANS object.
-    return new Promise(resolve => setTimeout(() => resolve(true), 300));
+export const updateMembershipPlanMock = async (planKey: string, updatedPlan: any) => {
+  await fetchJson(`/api/admin/membership-plans/${planKey}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updatedPlan)
+  });
 };
 
 export const getCreditPriceEditable = async (): Promise<number> => {
-    return new Promise(resolve => setTimeout(() => resolve(CREDIT_PRICE_VND), 200));
+  return fetchJson('/api/admin/credit-price');
 };
 
 export const updateCreditPriceMock = async (newPrice: number) => {
-    console.log("Mock update credit price:", newPrice);
-    // Similarly, this would update a backend.
-    return new Promise(resolve => setTimeout(() => resolve(true), 300));
+  await fetchJson('/api/admin/credit-price', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ price: newPrice })
+  });
 };
 
 export const getGeneratedCodes = async (): Promise<GeneratedCode[]> => {
-    return new Promise(resolve => {
-        setTimeout(() => resolve([...mockGeneratedCodes]), 300);
-    });
+  return fetchJson('/api/admin/generated-codes');
 };
 
 export const addGeneratedCode = async (code: GeneratedCode): Promise<GeneratedCode> => {
-    return new Promise(resolve => {
-        setTimeout(() => {
-            mockGeneratedCodes.unshift(code); // Add to the beginning
-            resolve(code);
-        }, 300);
-    });
+  return fetchJson('/api/admin/generated-codes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(code)
+  });
 };

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -1,150 +1,46 @@
-import { User, UserMembershipType, WorkerMembershipType } from '../types';
-import { DEFAULT_AVATAR_URL, MOCK_USER_EMAIL, MOCK_USER_PASSWORD, MOCK_WORKER_EMAIL, MOCK_WORKER_PASSWORD, MOCK_ADMIN_EMAIL, MOCK_ADMIN_PASSWORD, USER_MEMBERSHIP_PLANS, WORKER_MEMBERSHIP_PLANS } from '../constants';
+import { User } from '../types';
 
-// Simulate a database of users
-const users: User[] = [
-  {
-    id: 'user-demo-regular',
-    email: MOCK_USER_EMAIL,
-    name: 'Demo User',
-    avatarUrl: DEFAULT_AVATAR_URL,
-    credits: 100,
-    membership: UserMembershipType.Free,
-    membershipPlanName: USER_MEMBERSHIP_PLANS[UserMembershipType.Free].name,
-    membershipRoleType: 'user',
-    isAdmin: false,
-    isWorker: false,
-    phone: '0900123456'
-  },
-  {
-    id: 'user-admin-main',
-    email: MOCK_ADMIN_EMAIL,
-    name: 'Admin User',
-    avatarUrl: DEFAULT_AVATAR_URL,
-    credits: 9999,
-    membership: UserMembershipType.Professional, // Admins might have a user-type plan for previews
-    membershipPlanName: USER_MEMBERSHIP_PLANS[UserMembershipType.Professional].name,
-    membershipRoleType: 'admin', // Special role type for admin
-    isAdmin: true,
-    isWorker: false,
-    phone: '0987654321'
-  },
-  {
-    id: 'user-worker-demo',
-    email: MOCK_WORKER_EMAIL,
-    name: 'Demo Worker',
-    avatarUrl: DEFAULT_AVATAR_URL,
-    credits: 50,
-    membership: UserMembershipType.Free, // Workers might start free or a specific worker plan
-    membershipPlanName: WORKER_MEMBERSHIP_PLANS[WorkerMembershipType.WorkerAdvanced].name, // Default to a worker plan
-    membershipRoleType: 'worker',
-    isAdmin: false,
-    isWorker: true,
-    phone: '0912987654'
-  },
-];
+const fetchJson = async <T>(url: string, options?: RequestInit): Promise<T> => {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+};
 
-export const mockLogin = (email: string, pass: string): Promise<User | null> => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      const foundUser = users.find(u => u.email === email);
-      
-      if (foundUser) {
-        // In real app, verify password (pass === foundUser.passwordHash or similar)
-        // For mock, we use predefined passwords from constants
-        if (email === MOCK_ADMIN_EMAIL && pass === MOCK_ADMIN_PASSWORD && foundUser.isAdmin) {
-          resolve(foundUser);
-          return;
-        }
-        if (email === MOCK_WORKER_EMAIL && pass === MOCK_WORKER_PASSWORD && foundUser.isWorker) {
-          resolve(foundUser);
-          return;
-        }
-        if (email === MOCK_USER_EMAIL && pass === MOCK_USER_PASSWORD && !foundUser.isAdmin && !foundUser.isWorker) {
-          resolve(foundUser);
-          return;
-        }
-        // Fallback for other test users if passwords aren't strictly checked for them in mock
-        // resolve(foundUser); 
-        resolve(null); // If password doesn't match for specific mocks
-      } else {
-        resolve(null);
-      }
-    }, 500);
+export const login = async (email: string, pass: string): Promise<User | null> => {
+  return fetchJson<User | null>('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: pass })
   });
 };
 
-export const mockRegister = (name: string, email: string, _pass: string): Promise<User | null> => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      if (users.find(u => u.email === email)) {
-        resolve(null); // User already exists
-        return;
-      }
-      const newUser: User = {
-        id: `user${users.length + 1}`,
-        email,
-        name,
-        avatarUrl: DEFAULT_AVATAR_URL,
-        credits: 5, 
-        membership: UserMembershipType.Free,
-        membershipPlanName: USER_MEMBERSHIP_PLANS[UserMembershipType.Free].name,
-        membershipRoleType: 'user',
-        isAdmin: false,
-        isWorker: false,
-        phone: ''
-      };
-      users.push(newUser);
-      resolve(newUser);
-    }, 500);
+export const register = async (name: string, email: string, pass: string): Promise<User | null> => {
+  return fetchJson<User | null>('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email, password: pass })
   });
 };
 
-export const mockLogout = (): Promise<void> => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, 200);
+export const logout = async (): Promise<void> => {
+  await fetchJson('/api/auth/logout', { method: 'POST' });
+};
+
+export const getAllUsers = async (): Promise<User[]> => {
+  return fetchJson<User[]>('/api/admin/users');
+};
+
+export const updateUserByAdmin = async (updatedUser: User): Promise<User | null> => {
+  return fetchJson<User | null>(`/api/admin/users/${updatedUser.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updatedUser)
   });
 };
 
-// Function for admin to get all users (mock)
-export const getAllUsers = (): Promise<User[]> => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      // Return non-admin, non-worker users by default for "User Management"
-      resolve(users.filter(u => !u.isAdmin && !u.isWorker)); 
-    }, 300);
-  });
-};
-
-// Function for admin to update a user (mock)
-export const updateUserByAdmin = (updatedUser: User): Promise<User | null> => {
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            const index = users.findIndex(u => u.id === updatedUser.id);
-            if (index !== -1) {
-                users[index] = { ...users[index], ...updatedUser };
-                resolve(users[index]);
-            } else {
-                resolve(null);
-            }
-        }, 300);
-    });
-};
-
-// Function for admin to delete a user (mock)
-export const deleteUserByAdmin = (userId: string): Promise<boolean> => {
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            const index = users.findIndex(u => u.id === userId);
-            // Prevent deleting admin or worker from this generic function for safety
-            if (index !== -1 && !users[index].isAdmin && !users[index].isWorker) { 
-                users.splice(index, 1);
-                resolve(true);
-            } else {
-                resolve(false);
-            }
-        }, 300);
-    });
+export const deleteUserByAdmin = async (userId: string): Promise<boolean> => {
+  const res = await fetch(`/api/admin/users/${userId}`, { method: 'DELETE' });
+  return res.ok;
 };

--- a/services/dataService.ts
+++ b/services/dataService.ts
@@ -1,74 +1,32 @@
 
 import { ChecklistItem, GuidelineContent, TalentProfile, LegalDocument, ChatMessage } from '../types';
 
+const fetchJson = async <T>(url: string, options?: RequestInit): Promise<T> => {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+};
+
 export const getChecklistItems = async (): Promise<ChecklistItem[]> => {
-  return new Promise(resolve => {
-    setTimeout(() => resolve([
-      { id: 'fund1', text: 'Prepare Pitch Deck', completed: true, category: 'fundraising' },
-      { id: 'fund2', text: 'Identify Potential Investors', completed: false, category: 'fundraising' },
-      { id: 'fund3', text: 'Practice Pitch', completed: false, category: 'fundraising' },
-      { id: 'bm1', text: 'Define Value Proposition', completed: true, category: 'businessModel' },
-      { id: 'bm2', text: 'Analyze Target Market', completed: true, category: 'businessModel' },
-      { id: 'bm3', text: 'Develop Revenue Streams', completed: false, category: 'businessModel' },
-    ]), 300);
-  });
+  return fetchJson('/api/checklist');
 };
 
-export const getGuidelineData = async (): Promise<{ businessModel: GuidelineContent[], fundraising: GuidelineContent[] }> => {
-  // Content inspired by viet-kultura.com/ai/ but simplified
-  return new Promise(resolve => {
-    setTimeout(() => resolve({
-      businessModel: [
-        { title: "1. Customer Segments", points: ["Who are your most important customers?", "What are their archetypes?"] },
-        { title: "2. Value Propositions", points: ["What value do you deliver?", "Which customer problem are you solving?"] },
-        { title: "3. Channels", points: ["How do you reach your customers?", "Which channels are most cost-efficient?"] },
-        { title: "4. Customer Relationships", points: ["What type of relationship does each segment expect?", "How do you maintain them?"] },
-        { title: "5. Revenue Streams", points: ["For what value are customers willing to pay?", "How do they currently pay?"] },
-      ],
-      fundraising: [
-        { title: "1. Executive Summary", points: ["Company purpose", "Problem being solved", "Solution"] },
-        { title: "2. Team", points: ["Key team members and expertise", "Advisory board"] },
-        { title: "3. Market Analysis", points: ["Market size and growth potential", "Target audience"] },
-        { title: "4. Financial Projections", points: ["3-5 year forecast", "Key assumptions"] },
-        { title: "5. Funding Request", points: ["Amount sought", "Use of funds"] },
-      ],
-    }), 300);
-  });
+export const getGuidelineData = async (): Promise<{ businessModel: GuidelineContent[]; fundraising: GuidelineContent[] }> => {
+  return fetchJson('/api/guidelines');
 };
 
-export const getTalentProfiles = async (): Promise<{ suitable: TalentProfile[], invited: TalentProfile[], saved: TalentProfile[] }> => {
-  return new Promise(resolve => {
-    setTimeout(() => resolve({
-      suitable: [
-        { id: 'talent1', name: 'Alice Wonderland', role: 'Frontend Developer', matchScore: 92 },
-        { id: 'talent2', name: 'Bob The Builder', role: 'Project Manager', matchScore: 88 },
-      ],
-      invited: [
-        { id: 'talent3', name: 'Charlie Brown', role: 'UX Designer', matchScore: 95 },
-      ],
-      saved: [
-        { id: 'talent4', name: 'Diana Prince', role: 'Marketing Lead', matchScore: 90 },
-      ],
-    }), 300);
-  });
+export const getTalentProfiles = async (): Promise<{ suitable: TalentProfile[]; invited: TalentProfile[]; saved: TalentProfile[] }> => {
+  return fetchJson('/api/talent');
 };
 
 export const getLegalDocuments = async (): Promise<LegalDocument[]> => {
-  return new Promise(resolve => {
-    setTimeout(() => resolve([
-      { id: 'legal1', name: 'NDA_Template_v1.docx', type: 'NDA', uploadDate: '2024-07-01', score: 85, issues: ["Clause 3.2 unclear on duration"] },
-      { id: 'legal2', name: 'ServiceAgreement_ClientX.pdf', type: 'Service Agreement', uploadDate: '2024-06-15', score: 92, issues: [] },
-    ]), 300);
-  });
+  return fetchJson('/api/legal-documents');
 };
 
 export const getChatHistory = async (): Promise<ChatMessage[]> => {
-    return new Promise(resolve => {
-        setTimeout(() => resolve([
-            { id: 'msg1', sender: 'ai', text: 'Hello! How can I assist you with your business today?', timestamp: new Date(Date.now() - 60000 * 5) },
-            { id: 'msg2', sender: 'user', text: 'I need help refining my business model.', timestamp: new Date(Date.now() - 60000 * 4) },
-            { id: 'msg3', sender: 'ai', text: 'Great! Let\'s start with your value proposition. Can you describe it to me?', timestamp: new Date(Date.now() - 60000 * 3) },
-        ]), 300);
-    });
+  const data = await fetchJson<ChatMessage[]>('/api/chat/history');
+  return data.map(m => ({ ...m, timestamp: new Date(m.timestamp) }));
 };
     

--- a/services/workerDataService.ts
+++ b/services/workerDataService.ts
@@ -1,5 +1,12 @@
 import { CompanyView, WorkerScores, WorkerCertificateDetails, ClassSchedule, CompanyListingDetails } from '../types';
-import { DEFAULT_AVATAR_URL } from '../constants';
+
+const fetchJson = async <T>(url: string, options?: RequestInit): Promise<T> => {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+};
 
 export const getWorkerOverviewData = async (): Promise<{
   profileViews: CompanyView[];
@@ -7,38 +14,11 @@ export const getWorkerOverviewData = async (): Promise<{
   certificates: WorkerCertificateDetails[];
   verifications: { id: string; name: string; status: 'Verified' | 'Pending' | 'Not Verified'; verificationDate?: string }[];
 }> => {
-  return new Promise(resolve => {
-    setTimeout(() => resolve({
-      profileViews: [
-        { id: 'comp1', name: 'Tech Solutions Inc.', logoUrl: `https://via.placeholder.com/40/007bff/ffffff?text=TS`, viewDate: '2024-07-28' },
-        { id: 'comp2', name: 'Innovate Hub', logoUrl: `https://via.placeholder.com/40/28a745/ffffff?text=IH`, viewDate: '2024-07-27' },
-      ],
-      scores: {
-        trust: 85, // Points
-        heating: 70, // Points, could represent market demand or activity
-        growth: 90, // Points, potential for growth
-      },
-      certificates: [
-        { id: 'cert1', name: 'Advanced Frontend Development', issuer: 'viet-kultura.com', issueDate: '2024-06-15', isVerified: true, url: '#' },
-        { id: 'cert2', name: 'Project Management Fundamentals', issuer: 'Coursera', issueDate: '2023-12-01', isVerified: false },
-      ],
-      verifications: [
-        { id: 'ver1', name: 'Xác minh danh tính bởi Viet-Kultura', status: 'Verified', verificationDate: '2024-01-10' },
-        { id: 'ver2', name: 'Xác minh kinh nghiệm làm việc', status: 'Pending' },
-      ]
-    }), 300);
-  });
+  return fetchJson('/api/worker/overview');
 };
 
 export const getClassSchedules = async (): Promise<ClassSchedule[]> => {
-    return new Promise(resolve => {
-        setTimeout(() => resolve([
-            { id: 'class1', name: 'Advanced React Patterns', type: 'online', date: '2024-08-05', time: '18:00', platformOrLocation: 'Zoom (Link in email)', status: 'upcoming' },
-            { id: 'class2', name: 'Negotiation Skills Workshop', type: 'offline', date: '2024-08-10', time: '09:00', platformOrLocation: 'Viet-Kultura Office, HCMC', status: 'upcoming' },
-            { id: 'class3', name: 'Introduction to AI for Business', type: 'online', date: '2024-07-20', time: '14:00', platformOrLocation: 'Google Meet', status: 'in-progress', progress: 60 },
-            { id: 'class4', name: 'Data Structures & Algorithms', type: 'online', date: '2024-06-30', time: '10:00', platformOrLocation: 'Platform X', status: 'completed', progress: 100 },
-        ]), 300);
-    });
+  return fetchJson('/api/worker/classes');
 };
 
 export const getCompanyListings = async (): Promise<{
@@ -46,37 +26,5 @@ export const getCompanyListings = async (): Promise<{
   unverified: CompanyListingDetails[];
   invited: CompanyListingDetails[];
 }> => {
-  return new Promise(resolve => {
-    setTimeout(() => resolve({
-      verified: [
-        { 
-          id: 'compv1', name: 'FinTech Innovators', logoUrl: `https://via.placeholder.com/60/17a2b8/ffffff?text=FI`,
-          founders: ['Jane Doe', 'John Smith'], cLevel: ['CEO: Jane Doe', 'CTO: Alex Green'], keyMembers: ['Lead Dev: Sarah Lee'],
-          esopPolicy: 'Available, 5% pool', isopPolicy: 'Details upon request', fundingStage: 'Series A', capitalRaised: '$5M',
-          investors: ['Future Ventures', 'Growth Capital Partners'],
-          companyDescription: 'Revolutionizing financial services with AI-driven solutions. Looking for passionate engineers and product managers.',
-          aiPrediction: 'High growth potential in the next 2 years. Strong leadership team.',
-          latestNews: [{ title: 'FinTech Innovators secures $5M Series A', source: 'TechCrunch', date: '2024-07-15', url:'#' }],
-          scores: { trust: 92, growth: 88, heat: 75 }, isVerified: true,
-        },
-      ],
-      unverified: [
-        { 
-          id: 'compu1', name: 'Eco Sustainables', logoUrl: `https://via.placeholder.com/60/fd7e14/ffffff?text=ES`,
-          founders: ['Mike Brown'], cLevel: [], keyMembers: [],
-          companyDescription: 'Developing eco-friendly packaging solutions. Early stage, seeking seed funding.',
-          scores: { trust: 60, growth: 70, heat: 50 }, isVerified: false,
-        },
-      ],
-      invited: [
-        { 
-          id: 'compi1', name: 'HealthAI Corp', logoUrl: `https://via.placeholder.com/60/6f42c1/ffffff?text=HA`,
-          founders: ['Dr. Emily Carter'], cLevel: ['CEO: Dr. Emily Carter'], keyMembers: [],
-          esopPolicy: 'Generous ESOP for early hires', fundingStage: 'Seed', capitalRaised: '$500K',
-          companyDescription: 'Using AI to improve patient diagnostics. We have invited you to consider a Lead AI Researcher role.',
-          scores: { trust: 85, growth: 90, heat: 80 }, isVerified: true, status: 'invited'
-        },
-      ]
-    }), 500);
-  });
+  return fetchJson('/api/worker/company-listings');
 };


### PR DESCRIPTION
## Summary
- replace mock implementations in service modules with real `fetch` calls
- update `AuthContext` to use new auth API methods

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684f3c9da0908325941e723f05fe87fa